### PR TITLE
Add production Dockerfile, .dockerignore, and Render deployment docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.gitignore
+node_modules
+vendor
+var/cache
+var/log
+.env
+.env.*
+!.env.test
+coverage
+phpunit.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+# syntax=docker/dockerfile:1
+
+FROM composer:2 AS composer_deps
+WORKDIR /app
+
+COPY composer.json composer.lock symfony.lock ./
+RUN composer install \
+    --no-dev \
+    --no-interaction \
+    --no-progress \
+    --prefer-dist \
+    --optimize-autoloader \
+    --no-scripts
+
+FROM node:22-alpine AS frontend_builder
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml ./
+RUN corepack enable && pnpm install --frozen-lockfile
+
+COPY assets ./assets
+COPY public ./public
+COPY templates ./templates
+COPY src ./src
+COPY config ./config
+COPY vite.config.js ./
+RUN pnpm build
+
+FROM php:8.3-apache AS app
+WORKDIR /var/www/html
+
+ENV APP_ENV=prod \
+    APACHE_DOCUMENT_ROOT=/var/www/html/public
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    unzip \
+    libicu-dev \
+    libpq-dev \
+    && docker-php-ext-install intl pdo pdo_pgsql \
+    && a2enmod rewrite \
+    && sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf \
+    && sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=composer_deps /app/vendor ./vendor
+COPY . .
+COPY --from=frontend_builder /app/public/build ./public/build
+
+RUN mkdir -p var/cache var/log \
+    && chown -R www-data:www-data var
+
+EXPOSE 10000
+
+CMD ["sh", "-c", "sed -ri -e \"s/Listen 80/Listen ${PORT:-10000}/\" /etc/apache2/ports.conf && sed -ri -e \"s/:80>/:${PORT:-10000}>/\" /etc/apache2/sites-available/000-default.conf && apache2-foreground"]

--- a/README.md
+++ b/README.md
@@ -26,3 +26,43 @@ Optimize images for project images
 #### `./node_modules/imagemin-cli/cli.js --plugin.pngquant.quality={0.6,0.8} src/images/projects/* --out-dir=public/images/projects`
 
 This will optimize images for project images
+
+## Heroku ➜ Render migration checklist
+
+1. Create a **Web Service** in Render using this repository and set Runtime to **Docker** (Render will use `Dockerfile`).
+2. Set required environment variables in Render:
+   * `APP_ENV=prod`
+   * `APP_SECRET`
+   * `DATABASE_URL` (Render PostgreSQL Internal URL)
+   * Any third-party API keys currently in Heroku config vars (e.g. Strava credentials).
+3. Add a managed PostgreSQL instance in Render, then run migrations:
+   * `php bin/console doctrine:migrations:migrate --no-interaction`
+4. Confirm Symfony cache/log directories are writable (`var/cache`, `var/log`) and app boot succeeds.
+5. Verify front-end assets are built (`public/build`) from the Docker build stage.
+6. Configure health checks in Render (for example `/`).
+7. Point your custom domain to Render and wait for TLS provisioning.
+8. Run smoke tests:
+   * Homepage loads
+   * Blog routes load
+   * API endpoint(s) respond
+   * Strava connect flow works
+9. Keep Heroku app running during DNS propagation for rollback safety.
+10. After successful cutover and monitoring window, decommission Heroku resources.
+
+## Deploying on Render with Docker
+
+This repository now includes a production Dockerfile suitable for Render.
+
+### Local build/run
+
+```bash
+docker build -t jonnyeom-render .
+docker run --rm -p 10000:10000 \
+  -e PORT=10000 \
+  -e APP_ENV=prod \
+  -e APP_SECRET=change-me \
+  -e DATABASE_URL=postgresql://app:pass@host:5432/app?serverVersion=15&charset=utf8 \
+  jonnyeom-render
+```
+
+Then visit `http://localhost:10000`.


### PR DESCRIPTION
### Motivation

- Provide a production-ready container image and build pipeline for deploying the Symfony app on Render (migrating from Heroku).
- Ensure front-end assets and PHP dependencies are built in CI-friendly multi-stage Docker builds to produce a minimal runtime image.
- Document the Render migration and local Docker run steps to simplify deployments and troubleshooting.

### Description

- Add a multi-stage `Dockerfile` that builds Composer dependencies, runs a `pnpm` frontend build, and produces a `php:8.3-apache` runtime image with `public/build` and `vendor` copied in and `PORT`-aware Apache startup.
- Add a `.dockerignore` to exclude VCS, `node_modules`, `vendor`, `var` directories, environment files (except `.env.test`), and other build artifacts from Docker context.
- Update `README.md` with a `Heroku ➜ Render migration checklist`, Render-specific environment variable guidance, health checks, and a `docker build`/`docker run` example for local testing.
- The Docker image installs required system packages and PHP extensions (`intl`, `pdo`, `pdo_pgsql`) and configures Apache document root and permissions for `var/cache` and `var/log`.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b43b1e174c8332b2ddd3ecf721007a)